### PR TITLE
Update Sha of 3.6

### DIFF
--- a/Casks/python-framework-36.rb
+++ b/Casks/python-framework-36.rb
@@ -1,6 +1,6 @@
 cask 'python-framework-36' do
   version '3.6.8'
-  sha256 '4bcd53faffc98d193ef7cdccd5668de3829c702af4db45258819a84a2cab60d0'
+  sha256 '3c5fd87a231eca3ee138b0cdc2be6517a7ca428304d41901a86b51c6a22b910c'
 
   url "https://www.python.org/ftp/python/#{version}/python-#{version}-macosx10.6.pkg"
   name 'Python'


### PR DESCRIPTION
It looks like the sha was wrong; but for whatever reason it was not
installed via homebrew on travis/3.6 until a week or so ago as travis
images still ahd 3.6 (?). I did not manage to check the GPG signatre of
3.6 on python.org; so it would be good to do that as well;

This should solve failure of test on IPython repo.